### PR TITLE
Moved pythonlibs to module_utils to avoid usage of ENV vars

### DIFF
--- a/library/mt_command.py
+++ b/library/mt_command.py
@@ -43,8 +43,8 @@ EXAMPLES = '''
       password: 123
 '''
 
-import mt_api
-from mt_common import clean_params
+from ansible.module_utils import mt_api
+from ansible.module_utils.mt_common import clean_params
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_dhcp_server.py
+++ b/library/mt_dhcp_server.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
       dns:     192.168.1.20
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_hotspot.py
+++ b/library/mt_hotspot.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
       use-radius: yes
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_interface_bridge.py
+++ b/library/mt_interface_bridge.py
@@ -101,8 +101,8 @@ EXAMPLES = '''
     comment:       ansible_test
 '''
 
-import mt_api
-from mt_common import clean_params
+from ansible.module_utils import mt_api
+from ansible.module_utils.mt_common import clean_params
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_interface_bridge_port.py
+++ b/library/mt_interface_bridge_port.py
@@ -90,8 +90,8 @@ EXAMPLES = '''
     comment:       ansible_test
 '''
 
-import mt_api
-from mt_common import clean_params
+from ansible.module_utils import mt_api
+from ansible.module_utils.mt_common import clean_params
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_interface_wireless.py
+++ b/library/mt_interface_wireless.py
@@ -51,7 +51,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 
 
 def main():

--- a/library/mt_interfaces.py
+++ b/library/mt_interfaces.py
@@ -53,7 +53,7 @@ EXAMPLES = '''
         mtu:      1501
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_ip.py
+++ b/library/mt_ip.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 
 
 def main():

--- a/library/mt_ip_address.py
+++ b/library/mt_ip_address.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
     comment:    "link 3"
 '''
 
-import mt_api
+from ansible.module_utils import mt_api
 import socket
 
 #import mt_action #TODO: get this working

--- a/library/mt_ip_firewall.py
+++ b/library/mt_ip_firewall.py
@@ -55,7 +55,7 @@ EXAMPLES = '''
     password:  "{{ mt_pass }}"
     state:     present
     parameter: filter
-    settings:
+    rule:
       action: accept
       chain: forward
       comment: controlled by ansible
@@ -63,7 +63,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-import mt_api
+from ansible.module_utils import mt_api
 import re
 from copy import copy
 

--- a/library/mt_ip_firewall_addresslist.py
+++ b/library/mt_ip_firewall_addresslist.py
@@ -47,7 +47,7 @@ EXAMPLES = '''
       - 19.134.52.23/23
 '''
 
-import mt_api
+from ansible.module_utils import mt_api
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_login_test.py
+++ b/library/mt_login_test.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
 
 import json
-import mt_api
+from ansible.module_utils import mt_api
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/library/mt_neighbor.py
+++ b/library/mt_neighbor.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
       discover: "yes"
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_radius.py
+++ b/library/mt_radius.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from mt_common import MikrotikIdempotent
+from ansible.module_utils.mt_common import MikrotikIdempotent
 
 
 def main():

--- a/library/mt_radius_backup.py
+++ b/library/mt_radius_backup.py
@@ -89,7 +89,7 @@ EXAMPLES = '''
     timeout:        '2s500ms'
 '''
 
-import mt_api
+from ansible.module_utils import mt_api
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_snmp.py
+++ b/library/mt_snmp.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
       name: ansible_managed
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_system.py
+++ b/library/mt_system.py
@@ -51,7 +51,7 @@ EXAMPLES = '''
         name:    test_ansible
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_system_scheduler.py
+++ b/library/mt_system_scheduler.py
@@ -64,8 +64,8 @@ EXAMPLES = '''
     on_event:      put "hello"
 '''
 
-import mt_api
-from mt_common import clean_params
+from ansible.module_utils import mt_api
+from ansible.module_utils.mt_common import clean_params
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_tool.py
+++ b/library/mt_tool.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
       from:    foo@bar.com
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/library/mt_user.py
+++ b/library/mt_user.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
       group: read
 '''
 
-from mt_common import clean_params, MikrotikIdempotent
+from ansible.module_utils.mt_common import clean_params, MikrotikIdempotent
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/pythonlibs/mt_api/__init__.py
+++ b/pythonlibs/mt_api/__init__.py
@@ -7,9 +7,9 @@ import socket
 import ssl
 import sys
 
-from .retryloop import RetryError
-from .retryloop import retryloop
-from .socket_utils import set_keepalive
+from ansible.module_utils.mt_api.retryloop import RetryError
+from ansible.module_utils.mt_api.retryloop import retryloop
+from ansible.module_utils.mt_api.socket_utils import set_keepalive
 
 PY2 = sys.version_info[0] < 3
 logger = logging.getLogger(__name__)

--- a/pythonlibs/mt_common.py
+++ b/pythonlibs/mt_common.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import mt_api
+from ansible.module_utils import mt_api
 import re
 import sys
 

--- a/tests/integration/ansible.cfg
+++ b/tests/integration/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+module_utils   = ./pythonlibs/

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -4,7 +4,6 @@ ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 pushd .
 
 cd "$ABSOLUTE_PATH"
-export PYTHONPATH=./pythonlibs/
 ansible-playbook tests.yml --diff -i 127.0.0.1, $@
 
 popd  >/dev/null


### PR DESCRIPTION
I have rerun the test with simply using the following command without any ENV var:
``
ansible-playbook tests.yml --diff -i 127.0.0.1,
``